### PR TITLE
feat: add `static_openssl` feature for linking OpenSSL statically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 bindgen = ["authenticode-parser-sys/bindgen"]
 
 # If enabled the OpenSSL library is linked statically.
-static-openssl = ["authenticode-parser-sys/static-openssl"]
+openssl-static = ["authenticode-parser-sys/openssl-static"]
 
 [dependencies]
 authenticode-parser-sys = { path = "./authenticode-parser-sys", version = "0.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ rust-version = "1.65"
 [features]
 default = []
 bindgen = ["authenticode-parser-sys/bindgen"]
-static_openssl = ["authenticode-parser-sys/static_openssl"]
+
+# If enabled the OpenSSL library is linked statically.
+static-openssl = ["authenticode-parser-sys/static-openssl"]
 
 [dependencies]
 authenticode-parser-sys = { path = "./authenticode-parser-sys", version = "0.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.65"
 [features]
 default = []
 bindgen = ["authenticode-parser-sys/bindgen"]
+static_openssl = ["authenticode-parser-sys/static_openssl"]
 
 [dependencies]
 authenticode-parser-sys = { path = "./authenticode-parser-sys", version = "0.3.1" }

--- a/authenticode-parser-sys/Cargo.toml
+++ b/authenticode-parser-sys/Cargo.toml
@@ -21,7 +21,7 @@ default = []
 bindgen = ["dep:bindgen"]
 
 # If enabled the OpenSSL library is linked statically.
-static_openssl = []
+static-openssl = []
 
 [build-dependencies]
 # Used to compile the library.

--- a/authenticode-parser-sys/Cargo.toml
+++ b/authenticode-parser-sys/Cargo.toml
@@ -20,6 +20,9 @@ default = []
 # be used to force generating bindings at built time.
 bindgen = ["dep:bindgen"]
 
+# If enabled the OpenSSL library is linked statically.
+static_openssl = []
+
 [build-dependencies]
 # Used to compile the library.
 cc = "1.0"

--- a/authenticode-parser-sys/Cargo.toml
+++ b/authenticode-parser-sys/Cargo.toml
@@ -21,7 +21,7 @@ default = []
 bindgen = ["dep:bindgen"]
 
 # If enabled the OpenSSL library is linked statically.
-static-openssl = []
+openssl-static = []
 
 [build-dependencies]
 # Used to compile the library.

--- a/authenticode-parser-sys/build.rs
+++ b/authenticode-parser-sys/build.rs
@@ -67,13 +67,13 @@ fn main() {
         builder.include(include_dir);
     }
     builder.compile("authenticode-parser");
-    
+
     let link_mode = if cfg!(feature = "openssl-static") {
         "static"
     } else {
         "dylib"
     };
-    
+
     // Link to the built library, and to the openssl dependency
     if target.contains("windows-msvc") {
         println!("cargo:rustc-link-lib={}=libcrypto", link_mode);

--- a/authenticode-parser-sys/build.rs
+++ b/authenticode-parser-sys/build.rs
@@ -68,7 +68,7 @@ fn main() {
     }
     builder.compile("authenticode-parser");
     
-    let link_mode = if cfg!(feature = "static_openssl") {
+    let link_mode = if cfg!(feature = "static-openssl") {
         "static"
     } else {
         "dylib"

--- a/authenticode-parser-sys/build.rs
+++ b/authenticode-parser-sys/build.rs
@@ -67,15 +67,20 @@ fn main() {
         builder.include(include_dir);
     }
     builder.compile("authenticode-parser");
-
+    
+    let link_mode = if cfg!(feature = "static_openssl") {
+        "static"
+    } else {
+        "dylib"
+    };
+    
     // Link to the built library, and to the openssl dependency
     if target.contains("windows-msvc") {
-        println!("cargo:rustc-link-lib=dylib=libcrypto");
-
+        println!("cargo:rustc-link-lib={}=libcrypto", link_mode);
         println!("cargo:rustc-link-lib=dylib=user32");
         println!("cargo:rustc-link-lib=dylib=crypt32");
     } else {
-        println!("cargo:rustc-link-lib=dylib=crypto");
+        println!("cargo:rustc-link-lib={}=crypto", link_mode);
     }
 
     #[cfg(feature = "bindgen")]

--- a/authenticode-parser-sys/build.rs
+++ b/authenticode-parser-sys/build.rs
@@ -68,7 +68,7 @@ fn main() {
     }
     builder.compile("authenticode-parser");
     
-    let link_mode = if cfg!(feature = "static-openssl") {
+    let link_mode = if cfg!(feature = "openssl-static") {
         "static"
     } else {
         "dylib"


### PR DESCRIPTION
When the `static_openssl` feature is enabled, binaries that use this crate will contain a copy of OpenSSL statically linked, instead of depending on the OpenSSL being installed in the system.