### PR TITLE
fix: protect against null pointers returned by the C library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,7 +235,7 @@ impl Authenticode<'_> {
             // pointer and pass it to `std::slice::from_raw_parts` because this function
             // doesn't accept null pointers. We need a NonNull::dangling() pointer, which
             // is the right way of creating an empty slice with `std::slice::from_raw_parts`.
-            let counters = if this.counters == std::ptr::null_mut() {
+            let counters = if this.counters.is_null() {
                 std::ptr::NonNull::<Countersignature>::dangling().as_ptr()
             } else {
                 // Safety:
@@ -289,7 +289,7 @@ impl Signer<'_> {
             // Safety: pointer is not null.
             let this = unsafe { &(*self.0.chain) };
 
-            let certs = if this.certs == std::ptr::null_mut() {
+            let certs = if this.certs.is_null() {
                 std::ptr::NonNull::<Certificate>::dangling().as_ptr()
             } else {
                 // Safety:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,13 +231,19 @@ impl Authenticode<'_> {
             // Safety: pointer is not null.
             let this = unsafe { &(*self.0.countersigs) };
 
-            // Safety:
-            // The certs field has type `*mut *mut sys::Countersignature`. It is safe to cast
-            // to `*mut Countersignature` because:
-            // - The Countersignature type is a transparent wrapper on a &sys::Countersignature
-            // - The `*mut sys::Countersignature` pointers in the array are guaranteed to be
-            //   non-null (checked by auditing the C code).
-            let counters = this.counters.cast::<Countersignature>();
+            // `this.counters` may be null, and in that case we can't simply cast the null
+            // pointer and pass it to `std::slice::from_raw_parts` because this function
+            // doesn't accept null pointers. We need a NonNull::dangling() pointer, which
+            // is the right way of creating an empty slice with `std::slice::from_raw_parts`.
+            let counters = if this.counters != std::ptr::null_mut() {
+                // Safety:
+                // The certs field has type `*mut *mut sys::Countersignature`. It is safe to cast
+                // to `*mut Countersignature` because the Countersignature type is a transparent
+                // wrapper on a &sys::Countersignature.
+                this.counters.cast::<Countersignature>()
+            } else {
+                std::ptr::NonNull::<Countersignature>::dangling().as_ptr()
+            };
 
             // Safety:
             // - The counters + count pair is guaranteed by the library to represent an array.
@@ -283,13 +289,15 @@ impl Signer<'_> {
             // Safety: pointer is not null.
             let this = unsafe { &(*self.0.chain) };
 
-            // Safety:
-            // The certs field has type `*mut *mut sys::Certificate`. It is safe to cast
-            // to `*mut Certificate` because:
-            // - The Certificate type is a transparent wrapper on a &sys::Certificate
-            // - The `*mut sys::Certificate` pointers in the array are guaranteed to be non-null
-            //   (checked by auditing the C code).
-            let certs = this.certs.cast::<Certificate>();
+            let certs = if this.certs != std::ptr::null_mut() {
+                // Safety:
+                // The certs field has type `*mut *mut sys::Certificate`. It is safe to cast
+                // to `*mut Certificate` because the Certificate type is a transparent wrapper
+                // on a &sys::Certificate.
+                this.certs.cast::<Certificate>()
+            } else {
+                std::ptr::NonNull::<Certificate>::dangling().as_ptr()
+            };
 
             // Safety:
             // - The certs + count pair is guaranteed by the library to represent an array.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,14 +235,14 @@ impl Authenticode<'_> {
             // pointer and pass it to `std::slice::from_raw_parts` because this function
             // doesn't accept null pointers. We need a NonNull::dangling() pointer, which
             // is the right way of creating an empty slice with `std::slice::from_raw_parts`.
-            let counters = if this.counters != std::ptr::null_mut() {
+            let counters = if this.counters == std::ptr::null_mut() {
+                std::ptr::NonNull::<Countersignature>::dangling().as_ptr()
+            } else {
                 // Safety:
                 // The certs field has type `*mut *mut sys::Countersignature`. It is safe to cast
                 // to `*mut Countersignature` because the Countersignature type is a transparent
                 // wrapper on a &sys::Countersignature.
                 this.counters.cast::<Countersignature>()
-            } else {
-                std::ptr::NonNull::<Countersignature>::dangling().as_ptr()
             };
 
             // Safety:
@@ -289,14 +289,14 @@ impl Signer<'_> {
             // Safety: pointer is not null.
             let this = unsafe { &(*self.0.chain) };
 
-            let certs = if this.certs != std::ptr::null_mut() {
+            let certs = if this.certs == std::ptr::null_mut() {
+                std::ptr::NonNull::<Certificate>::dangling().as_ptr()
+            } else {
                 // Safety:
                 // The certs field has type `*mut *mut sys::Certificate`. It is safe to cast
                 // to `*mut Certificate` because the Certificate type is a transparent wrapper
                 // on a &sys::Certificate.
                 this.certs.cast::<Certificate>()
-            } else {
-                std::ptr::NonNull::<Certificate>::dangling().as_ptr()
             };
 
             // Safety:


### PR DESCRIPTION
This fixes two cases in which the C library could return a null pointer, and those pointers are passed to `std::slice::from_raw_parts`. According to the documentation `std::slice::from_raw_parts` doesn't accept null pointers, even if creating an empty slice.

This was causing a panic with code compiled with the nightly version of rustc, while parsing the file af3f20a9272489cbef4281c8c86ad42ccfb04ccedd3ada1e8c26939c726a4c8e.

Closes #13 